### PR TITLE
Add text labels to status badges

### DIFF
--- a/dashboards/components/BuildTimesDashboard.css
+++ b/dashboards/components/BuildTimesDashboard.css
@@ -492,16 +492,27 @@
   font-size: 13px;
 }
 
-/* Status Badges - Subtle Colors */
+/* Status Badges - With Text Labels */
 .status-badge {
-  display: inline-block;
-  width: 12px;
-  height: 12px;
-  border-radius: 50%;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 10px;
+  border-radius: 12px;
   font-size: 11px;
   font-weight: 600;
   text-transform: uppercase;
   letter-spacing: 0.5px;
+  white-space: nowrap;
+}
+
+.status-badge::before {
+  content: '';
+  display: inline-block;
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  flex-shrink: 0;
 }
 
 .status-success {
@@ -510,16 +521,28 @@
   border: 1px solid #9ae6b4;
 }
 
+.status-success::before {
+  background-color: #38a169;
+}
+
 .status-failed {
   background-color: #fed7d7;
   color: #742a2a;
   border: 1px solid #fc8181;
 }
 
+.status-failed::before {
+  background-color: #e53e3e;
+}
+
 .status-running {
   background-color: #feebc8;
   color: #7c2d12;
   border: 1px solid #fbd38d;
+}
+
+.status-running::before {
+  background-color: #ed8936;
   animation: pulse 2s ease-in-out infinite;
 }
 

--- a/dashboards/components/BuildTimesDashboard.js
+++ b/dashboards/components/BuildTimesDashboard.js
@@ -201,6 +201,19 @@ const BuildTimesDashboard = () => {
     }
   };
 
+  const getStatusText = (status) => {
+    switch (status) {
+      case 'success':
+        return 'Success';
+      case 'failed':
+        return 'Failed';
+      case 'running':
+        return 'Running';
+      default:
+        return status;
+    }
+  };
+
   // Custom Dropdown Component
   const CustomDropdown = ({ id, value, options, onChange, placeholder }) => {
     const isOpen = openDropdown === id;
@@ -407,7 +420,8 @@ const BuildTimesDashboard = () => {
                   <td className="branch-name">{build.branch}</td>
                   <td className="commit-hash">{build.commit}</td>
                   <td>
-                    <span className={`status-badge ${getStatusClass(build.status)}`} title={build.status}>
+                    <span className={`status-badge ${getStatusClass(build.status)}`}>
+                      {getStatusText(build.status)}
                     </span>
                   </td>
                   <td className="build-duration">{formatDuration(build.buildTime)}</td>


### PR DESCRIPTION
Fixes #48

## Changes
- ✅ Add visible text labels ("Success", "Failed", "Running") to status badges
- ✅ Include colored indicator dot before text using CSS ::before
- ✅ Status conveyed through both color AND text
- ✅ Maintain existing color scheme for visual consistency
- ✅ Ensure text has adequate contrast for readability

## WCAG Compliance
**1.4.1 Use of Color (Level A)** - Color must not be the only means of conveying information

## Before & After
**Before:** Empty colored circles (green/red/orange) with no text  
**After:** Badges with colored dot + text label (e.g., "● SUCCESS")

## Testing
- [x] Build succeeds
- [ ] Status badges display text labels
- [ ] Text is readable for all statuses
- [ ] Colorblind users can distinguish statuses by text
- [ ] Visual design remains clean and professional
- [ ] Screen readers announce status text

## Visual Design
Each status badge now shows:
- Colored background with border
- Small colored dot indicator (8px circle)
- Text label in uppercase
- Proper spacing and padding for readability