### PR TITLE
Add patterns and ARIA labels to chart bars

### DIFF
--- a/dashboards/components/BuildTimesDashboard.css
+++ b/dashboards/components/BuildTimesDashboard.css
@@ -126,6 +126,23 @@
 
 .chart-bar-failed {
   background: linear-gradient(to top, #fc8181, #f56565);
+  position: relative;
+}
+
+/* Add diagonal stripe pattern to failed builds for colorblind accessibility */
+.chart-bar-failed::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: repeating-linear-gradient(
+    45deg,
+    transparent,
+    transparent 4px,
+    rgba(0, 0, 0, 0.15) 4px,
+    rgba(0, 0, 0, 0.15) 8px
+  );
+  border-radius: 4px 4px 0 0;
+  pointer-events: none;
 }
 
 .chart-label {

--- a/dashboards/components/BuildTimesDashboard.js
+++ b/dashboards/components/BuildTimesDashboard.js
@@ -295,12 +295,16 @@ const BuildTimesDashboard = () => {
           {chartData.map((build, idx) => {
             const maxTime = Math.max(...chartData.map(b => b.buildTime));
             const height = (build.buildTime / maxTime) * 100;
+            const statusText = getStatusText(build.status);
+            const durationText = formatDuration(build.buildTime);
             return (
               <div key={build.id} className="chart-bar-wrapper">
                 <div
                   className={`chart-bar ${build.status === 'failed' ? 'chart-bar-failed' : ''}`}
                   style={{ height: `${height}%` }}
-                  title={`${build.id}: ${formatDuration(build.buildTime)}`}
+                  role="img"
+                  aria-label={`${build.id}: ${durationText}, Status: ${statusText}`}
+                  title={`${build.id}: ${durationText} - ${statusText}`}
                 />
                 <div className="chart-label">{idx % 3 === 0 ? `#${build.id.split('-')[1]}` : ''}</div>
               </div>


### PR DESCRIPTION
Fixes #49

## Changes
- ✅ Add `role="img"` to all chart bars  
- ✅ Add descriptive `aria-label` with build ID, duration, and status
- ✅ Update `title` attribute to include status information
- ✅ Add diagonal stripe pattern overlay to failed build bars
- ✅ Pattern provides visual distinction beyond color
- ✅ Screen readers announce complete information

## WCAG Compliance
**1.4.1 Use of Color (Level A)** - Color must not be the only means of conveying information

## Visual Enhancement
Failed builds now have a diagonal stripe pattern overlaid on the red bars, making them distinguishable from successful builds even in grayscale or for colorblind users.

## Accessibility Improvements
- **Screen readers:** Announce "build-1032: 8 minutes 22 seconds, Status: Failed"
- **Colorblind users:** Can see stripe pattern on failed builds
- **Keyboard users:** Can hover/focus bars and read full title text

## Testing
- [x] Build succeeds
- [ ] Chart bars have ARIA labels
- [ ] Failed builds show stripe pattern
- [ ] Pattern visible in grayscale
- [ ] Screen reader announces complete information
- [ ] Title tooltip shows status