### PR TITLE
Add label to search input

### DIFF
--- a/dashboards/components/BuildTimesDashboard.css
+++ b/dashboards/components/BuildTimesDashboard.css
@@ -1,3 +1,16 @@
+/* Screen reader only content */
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border-width: 0;
+}
+
 .build-times-dashboard {
   max-width: 1400px;
   margin: 0 auto;

--- a/dashboards/components/BuildTimesDashboard.js
+++ b/dashboards/components/BuildTimesDashboard.js
@@ -312,13 +312,21 @@ const BuildTimesDashboard = () => {
       {/* Filters and Search */}
       <div className="controls-container">
         <div className="search-box">
+          <label htmlFor="build-search" className="sr-only">
+            Search builds
+          </label>
           <input
             type="text"
+            id="build-search"
             placeholder="Search builds..."
             value={searchTerm}
             onChange={(e) => setSearchTerm(e.target.value)}
             className="search-input"
+            aria-describedby="search-help"
           />
+          <span id="search-help" className="sr-only">
+            Search by build ID, branch name, commit hash, or triggered by
+          </span>
         </div>
 
         <div className="filters">


### PR DESCRIPTION
Fixes #51

## Changes
- ✅ Add `<label>` element associated with search input via `htmlFor`/`id`
- ✅ Add `aria-describedby` for additional search context
- ✅ Use `.sr-only` class to hide label visually
- ✅ Provide helpful description of searchable fields
- ✅ Add `.sr-only` utility class to CSS

## WCAG Compliance
**3.3.2 Labels or Instructions (Level A)** - Labels must be provided for inputs  
**4.1.2 Name, Role, Value (Level A)** - Form elements must have accessible names

## Before & After
**Before:** Input with only placeholder text (not accessible to screen readers when focused)  
**After:** Input with proper `<label>` and descriptive help text

## Screen Reader Experience
When focusing the search input, screen readers will announce:
- "Search builds, edit text"
- "Search by build ID, branch name, commit hash, or triggered by"

## Testing
- [x] Build succeeds
- [ ] Screen reader announces label when focusing input
- [ ] Screen reader announces help text
- [ ] Label visually hidden but programmatically available
- [ ] Search functionality unchanged