### PR TITLE
Demo: deliberate a11y regression to exercise the full pipeline

### DIFF
--- a/dashboards/app/page.js
+++ b/dashboards/app/page.js
@@ -5,6 +5,9 @@ import BuildTimesDashboard from '../components/BuildTimesDashboard';
 export default function Home() {
   return (
     <div className="App">
+      {/* INTENTIONAL: demo regression for AccessLint/audit PR check */}
+      <img src="/logo512.png" />
+      <button onClick={() => alert('hi')}></button>
       <BuildTimesDashboard />
     </div>
   );


### PR DESCRIPTION
**Demo PR — exercises every layer of the AccessLint pipeline end-to-end.**

This PR adds two clear new accessibility violations to `dashboards/app/page.js`:

- `<img src="/logo512.png" />` — no `alt` attribute (critical, `text-alternatives/img-alt`)
- `<button onClick={…}></button>` — no accessible name (critical, `labels-and-names/button-name`)

Both are net-new vs. production, so the regression check should fire.

## Expected outcomes

| Layer | What should happen |
| --- | --- |
| **`audit-dev.yml`** (localhost dev server, multi-URL) | Source-mapped to `dashboards/app/page.js:9` and `:10`. Inline `::warning::` annotations on those lines in the "Files changed" tab. |
| **`audit-pr.yml`** (Netlify preview, regression mode) | Reports **2 NEW** violations (vs production's existing baseline). Sticky comment shows the regression report. |
| **SARIF → Code Scanning** | Posts review comments on the new lines (since they're within the diff). Alerts also visible in Security tab. |
| **Build status** | `audit-dev.yml` doesn't set `fail-on`, so green. `audit-pr.yml` doesn't set `fail-on` either, so green — the new violations are visible without forcing a hard gate. |

## After verification

This branch will be closed and the changes reverted. Pure demo of the v0.3.x pipeline.